### PR TITLE
customValue support for VNester and route elements

### DIFF
--- a/lib/src/vroute_elements/vnester.dart
+++ b/lib/src/vroute_elements/vnester.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:vrouter/src/vroute_elements/vnester_base.dart';
 import 'package:vrouter/src/vroute_elements/vpath.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_builder.dart';
+import 'package:vrouter/src/vroute_elements/vroute_element_with_custom_value.dart';
 import 'package:vrouter/src/vrouter_core.dart';
 
 /// A [VRouteElement] which enable nesting
@@ -32,6 +33,32 @@ import 'package:vrouter/src/vrouter_core.dart';
 ///
 /// {@tool snippet}
 ///
+/// If you have a bottom nav bar or tab bar and you want to nest multiple widgets
+/// (e.g., HomeWidget for /, ProfileWidget for /profile), telling MyScaffold what
+/// is the current tab based on the child route, do this:
+///
+/// ```dart
+/// VNester(
+///   path: '/',
+///   widgetBuilder: (child, customValue) => MyScaffold(child: child, currentIndex: customValue as int),
+///   nestedRoutes: [
+///     VWidget(
+///       path: null,
+///       customValue: 0,
+///       widget: HomeWidget(),
+///     ),
+///     VWidget(
+///       path: 'profile',
+///       customValue: 1,
+///       widget: ProfileWidget(),
+///     ),
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+///
 /// Note that you can also use stackedRoutes if you want to nest AND stack by using nestedRoutes
 /// AND stackedRoutes:
 ///
@@ -59,7 +86,7 @@ import 'package:vrouter/src/vrouter_core.dart';
 ///   * [VNesterBase] for a [VRouteElement] similar to [VNester] but which does NOT take path information
 ///   * [VNesterPage] for a [VRouteElement] similar to [VNester] but with which you can create you own page
 /// {@end-tool}
-class VNester extends VRouteElementBuilder {
+class VNester extends VRouteElementBuilder with VRouteElementWithCustomValue {
   /// A list of [VRouteElement] which widget will be accessible in [widgetBuilder]
   final List<VRouteElement> nestedRoutes;
 
@@ -104,10 +131,14 @@ class VNester extends VRouteElementBuilder {
   final List<String> aliases;
 
   /// A function which creates the [VRouteElement._rootVRouter] associated to this [VRouteElement]
+  /// Can have one of two types:
+  ///   - [Widget Function(Widget child)]
+  ///   - [Widget Function(Widget child, dynamic customValue)]
   ///
   /// [child] will be the [VRouteElement._rootVRouter] of the matched [VRouteElement] in
-  /// [nestedRoutes]
-  final Widget Function(Widget child) widgetBuilder;
+  /// [nestedRoutes]. [customValue] will be [VRouteElement.customValue] of the matched
+  /// [VRouteElement], if any.
+  final Function widgetBuilder;
 
   /// A LocalKey that will be given to the page which contains the given [_rootVRouter]
   ///
@@ -152,6 +183,10 @@ class VNester extends VRouteElementBuilder {
   /// differently and are also not closeable with the back swipe gesture.
   final bool fullscreenDialog;
 
+  /// A custom value that can be passed to [widgetBuilder] in a [VNester] if we're a nested child.
+  @override
+  final dynamic customValue;
+
   VNester({
     required this.path,
     required this.widgetBuilder,
@@ -165,6 +200,7 @@ class VNester extends VRouteElementBuilder {
     this.aliases = const [],
     this.navigatorKey,
     this.fullscreenDialog = false,
+    this.customValue,
   });
 
   /// Provides a [state] from which to access [VRouter] data in [widgetBuilder]
@@ -185,6 +221,7 @@ class VNester extends VRouteElementBuilder {
     List<String> aliases = const [],
     GlobalKey<NavigatorState>? navigatorKey,
     bool fullscreenDialog = false,
+    dynamic customValue,
   }) : this(
           path: path,
           widgetBuilder: (child) => VRouterDataBuilder(
@@ -200,6 +237,7 @@ class VNester extends VRouteElementBuilder {
           aliases: aliases,
           navigatorKey: navigatorKey,
           fullscreenDialog: fullscreenDialog,
+          customValue: customValue,
         );
 
   @override
@@ -220,6 +258,7 @@ class VNester extends VRouteElementBuilder {
               reverseTransitionDuration: reverseTransitionDuration,
               navigatorKey: navigatorKey,
               fullscreenDialog: fullscreenDialog,
+              customValue: customValue,
             ),
           ],
         ),

--- a/lib/src/vroute_elements/vnester_base.dart
+++ b/lib/src/vroute_elements/vnester_base.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:vrouter/src/vroute_elements/vnester_page_base.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_builder.dart';
+import 'package:vrouter/src/vroute_elements/vroute_element_with_custom_value.dart';
 import 'package:vrouter/src/vrouter_core.dart';
 import 'package:vrouter/src/vrouter_helpers.dart';
 
@@ -57,7 +58,8 @@ import 'package:vrouter/src/vrouter_helpers.dart';
 /// Also see:
 ///   * [VNester] for a [VRouteElement] similar to [VNesterBase] but which take path information
 /// {@end-tool}
-class VNesterBase extends VRouteElementBuilder {
+class VNesterBase extends VRouteElementBuilder
+    with VRouteElementWithCustomValue {
   /// A list of [VRouteElement] which widget will be accessible in [widgetBuilder]
   final List<VRouteElement> nestedRoutes;
 
@@ -67,10 +69,14 @@ class VNesterBase extends VRouteElementBuilder {
   final List<VRouteElement> stackedRoutes;
 
   /// A function which creates the [VRouteElement._rootVRouter] associated to this [VRouteElement]
+  /// Can have one of two types:
+  ///   - [Widget Function(Widget child)]
+  ///   - [Widget Function(Widget child, dynamic customValue)]
   ///
   /// [child] will be the [VRouteElement._rootVRouter] of the matched [VRouteElement] in
-  /// [nestedRoutes]
-  final Widget Function(Widget child) widgetBuilder;
+  /// [nestedRoutes]. [customValue] will be [VRouteElement.customValue] of the matched
+  /// [VRouteElement], if any.
+  final Function widgetBuilder;
 
   /// A LocalKey that will be given to the page which contains the given [widget]
   ///
@@ -121,6 +127,10 @@ class VNesterBase extends VRouteElementBuilder {
   /// differently and are also not closeable with the back swipe gesture.
   final bool fullscreenDialog;
 
+  /// A custom value that can be passed to [widgetBuilder] in a [VNester] if we're a nested child.
+  @override
+  final dynamic customValue;
+
   VNesterBase({
     required this.widgetBuilder,
     required this.nestedRoutes,
@@ -132,6 +142,7 @@ class VNesterBase extends VRouteElementBuilder {
     this.stackedRoutes = const [],
     this.navigatorKey,
     this.fullscreenDialog = false,
+    this.customValue,
   });
 
   /// Provides a [state] from which to access [VRouter] data in [widgetBuilder]
@@ -150,6 +161,7 @@ class VNesterBase extends VRouteElementBuilder {
     List<VRouteElement> stackedRoutes = const [],
     GlobalKey<NavigatorState>? navigatorKey,
     fullscreenDialog = false,
+    dynamic customValue,
   }) : this(
           widgetBuilder: (child) => VRouterDataBuilder(
             builder: (context, state) => widgetBuilder(context, state, child),
@@ -163,6 +175,7 @@ class VNesterBase extends VRouteElementBuilder {
           stackedRoutes: stackedRoutes,
           navigatorKey: navigatorKey,
           fullscreenDialog: fullscreenDialog,
+          customValue: customValue,
         );
 
   @override
@@ -185,6 +198,7 @@ class VNesterBase extends VRouteElementBuilder {
             reverseTransitionDuration: reverseTransitionDuration,
             fullscreenDialog: fullscreenDialog,
           ),
+          customValue: customValue,
         ),
       ];
 }

--- a/lib/src/vroute_elements/vnester_page.dart
+++ b/lib/src/vroute_elements/vnester_page.dart
@@ -2,11 +2,13 @@ import 'package:flutter/widgets.dart';
 import 'package:vrouter/src/vroute_elements/vnester_page_base.dart';
 import 'package:vrouter/src/vroute_elements/vpath.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_builder.dart';
+import 'package:vrouter/src/vroute_elements/vroute_element_with_custom_value.dart';
 import 'package:vrouter/src/vrouter_core.dart';
 
 /// A [VRouteElement] similar to [VNester] but which allows you to specify your own page
 /// thanks to [pageBuilder]
-class VNesterPage extends VRouteElementBuilder {
+class VNesterPage extends VRouteElementBuilder
+    with VRouteElementWithCustomValue {
   /// A list of routes which:
   ///   - path NOT starting with '/' will be relative to [path]
   ///   - widget or page will be nested inside [widgetBuilder]
@@ -26,10 +28,14 @@ class VNesterPage extends VRouteElementBuilder {
       LocalKey key, Widget child, String? name, VRouterData state) pageBuilder;
 
   /// A function which creates the [VRouteElement._rootVRouter] associated to this [VRouteElement]
+  /// Can have one of two types:
+  ///   - [Widget Function(Widget child)]
+  ///   - [Widget Function(Widget child, dynamic customValue)]
   ///
   /// [child] will be the [VRouteElement._rootVRouter] of the matched [VRouteElement] in
-  /// [nestedRoutes]
-  final Widget Function(Widget child) widgetBuilder;
+  /// [nestedRoutes]. [customValue] will be [VRouteElement.customValue] of the matched
+  /// [VRouteElement], if any.
+  final Function widgetBuilder;
 
   /// The path (relative or absolute) or this [VRouteElement]
   ///
@@ -87,6 +93,10 @@ class VNesterPage extends VRouteElementBuilder {
   /// and the animations will be as expected
   final GlobalKey<NavigatorState>? navigatorKey;
 
+  /// A custom value that can be passed to [widgetBuilder] in a [VNester] if we're a nested child.
+  @override
+  final dynamic customValue;
+
   VNesterPage({
     required this.path,
     required Page Function(LocalKey key, Widget child, String? name)
@@ -98,6 +108,7 @@ class VNesterPage extends VRouteElementBuilder {
     this.stackedRoutes = const [],
     this.aliases = const [],
     this.navigatorKey,
+    this.customValue,
   }) : this.pageBuilder =
             ((LocalKey key, Widget child, String? name, VRouterData state) =>
                 pageBuilder(key, child, name));
@@ -117,6 +128,7 @@ class VNesterPage extends VRouteElementBuilder {
     List<VRouteElement> stackedRoutes = const [],
     List<String> aliases = const [],
     GlobalKey<NavigatorState>? navigatorKey,
+    dynamic customValue,
   })  : this.path = path,
         this.pageBuilder = pageBuilder,
         this.widgetBuilder = ((child) => VRouterDataBuilder(
@@ -126,7 +138,8 @@ class VNesterPage extends VRouteElementBuilder {
         this.name = name,
         this.stackedRoutes = stackedRoutes,
         this.aliases = aliases,
-        this.navigatorKey = navigatorKey;
+        this.navigatorKey = navigatorKey,
+        this.customValue = customValue;
 
   @override
   List<VRouteElement> buildRoutes() => [
@@ -143,6 +156,7 @@ class VNesterPage extends VRouteElementBuilder {
               widgetBuilder: widgetBuilder,
               pageBuilder: pageBuilder,
               navigatorKey: navigatorKey,
+              customValue: customValue,
             ),
           ],
         ),

--- a/lib/src/vroute_elements/vpage.dart
+++ b/lib/src/vroute_elements/vpage.dart
@@ -2,9 +2,10 @@ import 'package:flutter/widgets.dart';
 import 'package:vrouter/src/vroute_elements/vpage_base.dart';
 import 'package:vrouter/src/vroute_elements/vpath.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_builder.dart';
+import 'package:vrouter/src/vroute_elements/vroute_element_with_custom_value.dart';
 import 'package:vrouter/src/vrouter_core.dart';
 
-class VPage extends VRouteElementBuilder {
+class VPage extends VRouteElementBuilder with VRouteElementWithCustomValue {
   /// The path (relative or absolute) or this [VRouteElement]
   ///
   /// If the path of a subroute is exactly matched, this will be used in
@@ -34,6 +35,10 @@ class VPage extends VRouteElementBuilder {
   ///
   /// Note that [name] should be unique w.r.t every [VRouteElement]
   final String? name;
+
+  /// A custom value that can be passed to [widgetBuilder] in a [VNester] if we're a nested child.
+  @override
+  final dynamic customValue;
 
   /// Alternative paths that will be matched to this route
   ///
@@ -75,6 +80,7 @@ class VPage extends VRouteElementBuilder {
     this.stackedRoutes = const [],
     this.key,
     this.name,
+    this.customValue,
     this.aliases = const [],
     this.mustMatchStackedRoute = false,
   });
@@ -86,6 +92,7 @@ class VPage extends VRouteElementBuilder {
     List<VRouteElement> stackedRoutes = const [],
     LocalKey? key,
     String? name,
+    dynamic customValue,
     List<String> aliases = const [],
     bool mustMatchStackedRoute = false,
   }) : this(
@@ -95,6 +102,7 @@ class VPage extends VRouteElementBuilder {
           stackedRoutes: stackedRoutes,
           key: key,
           name: name,
+          customValue: customValue,
           aliases: aliases,
           mustMatchStackedRoute: mustMatchStackedRoute,
         );
@@ -111,6 +119,7 @@ class VPage extends VRouteElementBuilder {
               widget: widget,
               key: key,
               name: name,
+              customValue: customValue,
               stackedRoutes: stackedRoutes,
             ),
           ],

--- a/lib/src/vroute_elements/vpage_base.dart
+++ b/lib/src/vroute_elements/vpage_base.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:vrouter/src/vroute_elements/void_vguard.dart';
 import 'package:vrouter/src/vroute_elements/void_vpop_handler.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_single_subroute.dart';
+import 'package:vrouter/src/vroute_elements/vroute_element_with_custom_value.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_with_page.dart';
 import 'package:vrouter/src/vrouter_core.dart';
 
@@ -11,6 +12,7 @@ class VPageBase extends VRouteElement
     with
         VRouteElementSingleSubRoute,
         VRouteElementWithPage,
+        VRouteElementWithCustomValue,
         VoidVGuard,
         VoidVPopHandler {
   /// A function which allows you to use your own custom page
@@ -32,6 +34,9 @@ class VPageBase extends VRouteElement
   final String? name;
 
   @override
+  final dynamic customValue;
+
+  @override
   final List<VRouteElement> stackedRoutes;
 
   VPageBase({
@@ -39,6 +44,7 @@ class VPageBase extends VRouteElement
     required this.widget,
     this.key,
     this.name,
+    this.customValue,
     this.stackedRoutes = const [],
   });
 
@@ -48,12 +54,14 @@ class VPageBase extends VRouteElement
     required Widget Function(BuildContext context, VRouterData state) builder,
     LocalKey? key,
     String? name,
+    dynamic customValue,
     List<VRouteElement> stackedRoutes = const [],
   }) : this(
           pageBuilder: pageBuilder,
           widget: VRouterDataBuilder(builder: builder),
           key: key,
           name: name,
+          customValue: customValue,
           stackedRoutes: stackedRoutes,
         );
 

--- a/lib/src/vroute_elements/vroute_element_with_custom_value.dart
+++ b/lib/src/vroute_elements/vroute_element_with_custom_value.dart
@@ -1,0 +1,5 @@
+import 'package:vrouter/src/vrouter_core.dart';
+
+mixin VRouteElementWithCustomValue on VRouteElement {
+  dynamic get customValue;
+}

--- a/lib/src/vroute_elements/vwidget.dart
+++ b/lib/src/vroute_elements/vwidget.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/widgets.dart';
 import 'package:vrouter/src/vroute_elements/vpath.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_builder.dart';
+import 'package:vrouter/src/vroute_elements/vroute_element_with_custom_value.dart';
 import 'package:vrouter/src/vroute_elements/vwidget_base.dart';
 import 'package:vrouter/src/vrouter_core.dart';
 
-class VWidget extends VRouteElementBuilder {
+class VWidget extends VRouteElementBuilder with VRouteElementWithCustomValue {
   /// The path (relative or absolute) or this [VRouteElement]
   ///
   /// If the path of a subroute is exactly matched, this will be used in
@@ -34,6 +35,10 @@ class VWidget extends VRouteElementBuilder {
   ///
   /// Note that [name] should be unique w.r.t every [VRouteElement]
   final String? name;
+
+  /// A custom value that can be passed to [widgetBuilder] in a [VNester] if we're a nested child.
+  @override
+  final dynamic customValue;
 
   /// Alternative paths that will be matched to this route
   ///
@@ -92,6 +97,7 @@ class VWidget extends VRouteElementBuilder {
     this.reverseTransitionDuration,
     this.buildTransition,
     this.fullscreenDialog = false,
+    this.customValue,
   });
 
   VWidget.builder({
@@ -107,6 +113,7 @@ class VWidget extends VRouteElementBuilder {
             Animation<double> secondaryAnimation, Widget child)?
         buildTransition,
     bool fullscreenDialog = false,
+    dynamic customValue,
   }) : this(
           path: path,
           widget: VRouterDataBuilder(builder: builder),
@@ -118,6 +125,7 @@ class VWidget extends VRouteElementBuilder {
           reverseTransitionDuration: reverseTransitionDuration,
           buildTransition: buildTransition,
           fullscreenDialog: fullscreenDialog,
+          customValue: customValue,
         );
 
   @override
@@ -136,6 +144,7 @@ class VWidget extends VRouteElementBuilder {
               transitionDuration: transitionDuration,
               reverseTransitionDuration: reverseTransitionDuration,
               fullscreenDialog: fullscreenDialog,
+              customValue: customValue,
             ),
           ],
         ),

--- a/lib/src/vroute_elements/vwidget_base.dart
+++ b/lib/src/vroute_elements/vwidget_base.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/widgets.dart';
 import 'package:vrouter/src/vroute_elements/vpage_base.dart';
 import 'package:vrouter/src/vroute_elements/vroute_element_builder.dart';
+import 'package:vrouter/src/vroute_elements/vroute_element_with_custom_value.dart';
 import 'package:vrouter/src/vrouter_core.dart';
 import 'package:vrouter/src/vrouter_helpers.dart';
 
-class VWidgetBase extends VRouteElementBuilder {
+class VWidgetBase extends VRouteElementBuilder
+    with VRouteElementWithCustomValue {
   /// A list of routes which:
   ///   - path NOT starting with '/' will be relative to [path]
   ///   - widget or page will be stacked on top of [widget]
@@ -29,6 +31,10 @@ class VWidgetBase extends VRouteElementBuilder {
   ///
   /// Note that [name] should be unique w.r.t every [VRouteElement]
   final String? name;
+
+  /// A custom value that can be passed to [widgetBuilder] in a [VNester] if we're a nested child.
+  @override
+  final dynamic customValue;
 
   /// The duration of [VWidgetBase.buildTransition]
   final Duration? transitionDuration;
@@ -61,6 +67,7 @@ class VWidgetBase extends VRouteElementBuilder {
     this.reverseTransitionDuration,
     this.buildTransition,
     this.fullscreenDialog = false,
+    this.customValue,
   });
 
   VWidgetBase.builder({
@@ -74,6 +81,7 @@ class VWidgetBase extends VRouteElementBuilder {
             Animation<double> secondaryAnimation, Widget child)?
         buildTransition,
     bool fullscreenDialog = false,
+    dynamic customValue,
   }) : this(
           widget: VRouterDataBuilder(builder: builder),
           stackedRoutes: stackedRoutes,
@@ -83,6 +91,7 @@ class VWidgetBase extends VRouteElementBuilder {
           reverseTransitionDuration: reverseTransitionDuration,
           buildTransition: buildTransition,
           fullscreenDialog: fullscreenDialog,
+          customValue: customValue,
         );
 
   @override
@@ -101,6 +110,7 @@ class VWidgetBase extends VRouteElementBuilder {
           key: key,
           name: name,
           stackedRoutes: stackedRoutes,
+          customValue: customValue,
         ),
       ];
 }

--- a/lib/src/vrouter_vroute_elements.dart
+++ b/lib/src/vrouter_vroute_elements.dart
@@ -15,6 +15,7 @@ export 'vroute_elements/vwidget.dart';
 export 'vroute_elements/vwidget_base.dart';
 
 export 'vroute_elements/vroute_element_single_subroute.dart';
+export 'vroute_elements/vroute_element_with_custom_value.dart';
 export 'vroute_elements/vroute_element_with_name.dart';
 export 'vroute_elements/void_vguard.dart';
 export 'vroute_elements/void_vpop_handler.dart';

--- a/lib/vrouter.dart
+++ b/lib/vrouter.dart
@@ -9,7 +9,8 @@ export 'package:vrouter/src/vrouter_vroute_elements.dart'
         VRouteElementSingleSubRoute,
         VoidVGuard,
         VoidVPopHandler,
-        VRouteElementWithName;
+        VRouteElementWithName,
+        VRouteElementWithCustomValue;
 export 'package:vrouter/src/vrouter_scope.dart';
 
 export 'package:vrouter/src/vrouter_helpers.dart';


### PR DESCRIPTION
This enhancement is motivated by the code example [here](https://github.com/lulupointu/vrouter/issues/32#issuecomment-885035432) from #32 to use `VNester` and sync bottom nav bar and nested tab bar with routes while preserving state.

While the code example from the linked comment above works, you have to repeat the whole `VNester` and the `widgetBuilder` (only varying the `currentIndex` in the constructor to the widget). This gets pretty cumbersome if you have more complex nested routes with `VGuard` or as the nesting level goes 3-deep in a more complex app.

The reason why the whole `VNester` has to be repeated in the example is that there is no way to associate with the child widget the tab index (even a mixin to Widget won't work, as the actual child widget is wrapped in a `Builder` and cannot be accessed directly from the `child` parameter passed to the `widgetBuilder` function).

This PR adds the concept of an optional `customValue` dynamic value to `VRouteElement`, and then an optional second type of `widgetBuilder` that will take `(child, customValue)` instead of just `(child)`. `VNester` is enhanced to then search for and provide the "nearest" customValue on the matched route to the child to the `widgetBuilder` (logic to do this only happens if `widgetBuilder` has the new type -- the old type is still accepted for backwards compatibility as well). This simplifies the code example to the following:

<details>
<summary>Show modified "advanced" example that uses `customValue`</summary>

```dart
import 'package:flutter/material.dart';
import 'package:vrouter/vrouter.dart';

void main() {
  runApp(
    VRouter(
      debugShowCheckedModeBanner: false,
      routes: [
        VNester(
          path: '/',
          widgetBuilder: (child, customValue) =>
              MyScaffold(child, currentIndex: customValue as int),
          nestedRoutes: [
            VWidget(
              path: null,
              key: ValueKey('Home'),
              customValue: 0,
              widget: HomeScreen(),
              stackedRoutes: [
                VNester(
                  path: null,
                  widgetBuilder: (child, customValue) =>
                      MyTabs(child, currentIndex: customValue as int),
                  nestedRoutes: [
                    VWidget(
                        path: 'red',
                        customValue: 0,
                        widget:
                            ColorScreen(color: Colors.redAccent, title: 'Red')),
                    VWidget(
                        path: 'green',
                        customValue: 1,
                        widget: ColorScreen(
                            color: Colors.greenAccent, title: 'Green')),
                  ],
                ),
              ],
            ),
            VWidget(
              path: 'profile',
              customValue: 1,
              widget: ProfileScreen(),
              stackedRoutes: [
                VWidget(path: 'settings', widget: SettingsScreen())
              ],
            ),
          ],
        ),
      ],
    ),
  );
}

class BaseWidget extends StatefulWidget {
  final String title;
  final String buttonText;
  final String to;

  BaseWidget({required this.title, required this.buttonText, required this.to});

  @override
  _BaseWidgetState createState() => _BaseWidgetState();
}

class _BaseWidgetState extends State<BaseWidget> {
  bool isChecked = false;

  @override
  Widget build(BuildContext context) {
    return Material(
      child: Center(
        child: Column(
          mainAxisSize: MainAxisSize.min,
          children: [
            Text(widget.title),
            SizedBox(height: 50),
            ElevatedButton(
              onPressed: () => context.vRouter.to(widget.to),
              child: Text(widget.buttonText),
            ),
            SizedBox(height: 50),
            Checkbox(
              value: isChecked,
              onChanged: (value) => setState(() => isChecked = value ?? false),
            ),
          ],
        ),
      ),
    );
  }
}

class MyScaffold extends StatefulWidget {
  final Widget child;
  final int currentIndex;

  const MyScaffold(this.child, {required this.currentIndex});

  @override
  _MyScaffoldState createState() => _MyScaffoldState();
}

class _MyScaffoldState extends State<MyScaffold> {
  List<Widget> tabs = [Container(), Container()];

  List<String> tabsLastVisitedUrls = ['/', '/profile'];

  @override
  Widget build(BuildContext context) {
    // Populate the tabs when needed
    tabs[widget.currentIndex] = widget.child;

    // Populate tabs last visited url
    tabsLastVisitedUrls[widget.currentIndex] = context.vRouter.url;

    return Scaffold(
      body: IndexedStack(
        index: widget.currentIndex,
        children: tabs,
      ),
      bottomNavigationBar: BottomNavigationBar(
        currentIndex: widget.currentIndex,
        onTap: (value) => context.vRouter.to(tabsLastVisitedUrls[value]),
        items: [
          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Profile'),
        ],
      ),
    );
  }
}

class HomeScreen extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return BaseWidget(
        title: 'Home', buttonText: 'Go to Color Tabs', to: '/red');
  }
}

class SettingsScreen extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return BaseWidget(title: 'Settings', buttonText: 'Pop', to: '/profile');
  }
}

class ProfileScreen extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return BaseWidget(
        title: 'Profile',
        buttonText: 'Go to Settings',
        to: '/profile/settings');
  }
}

class MyTabs extends StatefulWidget {
  final Widget child;
  final int currentIndex;

  const MyTabs(this.child, {required this.currentIndex});

  @override
  _MyTabsState createState() => _MyTabsState();
}

class _MyTabsState extends State<MyTabs> with SingleTickerProviderStateMixin {
  late final tabController = TabController(
    initialIndex: widget.currentIndex,
    length: tabs.length,
    vsync: this,
  );

  // We use this as the index to easily fetch the new widget when in comes into view
  int get tabControllerIndex =>
      tabController.index + tabController.offset.sign.toInt();

  List<Widget> tabs = [Container(), Container()];

  @override
  Widget build(BuildContext context) {
    // Sync the tabController with the url
    if (!tabController.indexIsChanging &&
        tabControllerIndex != widget.currentIndex)
      tabController.animateTo(widget.currentIndex);

    // Populate the tabs when needed
    tabs[widget.currentIndex] = widget.child;
    tabs = List.from(tabs); // Needed so that TabBarView updates its children

    return Scaffold(
      appBar: AppBar(
        title: const Text('Colors'),
        bottom: TabBar(
          controller: tabController,
          tabs: const [Tab(text: 'Red'), Tab(text: 'Green')],
        ),
      ),
      body: NotificationListener<ScrollNotification>(
        onNotification: (_) {
          // Syncs the url with the tabController
          if (tabControllerIndex != widget.currentIndex)
            context.vRouter.to(tabControllerIndex == 0 ? '/red' : '/green');
          return false;
        },
        child: TabBarView(
          controller: tabController,
          children: tabs,
        ),
      ),
    );
  }
}

class ColorScreen extends StatefulWidget {
  final Color color;
  final String title;

  const ColorScreen({required this.color, required this.title});

  @override
  _ColorScreenState createState() => _ColorScreenState();
}

class _ColorScreenState extends State<ColorScreen>
    with AutomaticKeepAliveClientMixin<ColorScreen> {
  bool isChecked = false;

  @override
  Widget build(BuildContext context) {
    super.build(context);

    return Container(
      color: widget.color,
      child: Center(
        child: Column(
          mainAxisSize: MainAxisSize.min,
          children: [
            Text(widget.title),
            SizedBox(height: 50),
            ElevatedButton(
              onPressed: () => context.vRouter.to('/'),
              child: Text('Pop'),
            ),
            SizedBox(height: 50),
            Checkbox(
              value: isChecked,
              onChanged: (value) => setState(() => isChecked = value ?? false),
            ),
          ],
        ),
      ),
    );
  }

  @override
  bool get wantKeepAlive => true;
}
```
</details>

However, it is causing an issue where after navigating back and forth between different nested routes now that there is only a single VNester, flutter (2.8.0) throws the error:
```
════════ Exception caught by widgets library ═══════════════════════════════════
Duplicate GlobalKey detected in widget tree.
════════════════════════════════════════════════════════════════════════════════
```

(Note that there is a RenderIndexedStack exception getting thrown sometimes too, but that wasn't happening in the full-scale app, it was just the Duplicate GlobalKey exception that was occurring whenever changing the route to a different tab at the same "nesting level" as the current route.)

And inspecting the debug label of the `GlobalKey`, it is the global key of the top-most level VNester. Using multiple VNesters like the original example (even with customValue) doesn't have this problem, so it doesn't seem like the customValue changes cause this directly, but it might be something unexpected with how this is working now that only a single VNester is needed at each level. I'm not a flutter expert (yet!), and so was hoping @lulupointu you might have some insights why this might be happening / how to fix it.

I'd also love your feedback on the general direction of this PR as well! At first I tried to add a custom value chain (similar to name) in `VRoute`, but this was complex and also was difficult to know exactly which customValue should be passed to `widgetBuilder` (especially when there are multiple nested VNester). This PR is the second attempt that is simpler where it just searches the element list (which does have only the list of child route elements at the point of VNester, so it was both simpler and worked with all levels of nesting).

In the meantime, I made a custom `VRouteElementBuilder` that generates the multiple `VNester` (one for each tab) so that it removes boilerplate / duplicate code, and still works with the current vRouter as released. In case it's useful to anyone:

<details>
<summary>Show code for TabbedNester</summary>

```dart
class TabbedNesterEntry {
  final List<VRouteElement> nestedRoutes;
  final List<VRouteElement> stackedRoutes;

  TabbedNesterEntry(
    this.nestedRoutes, {
    this.stackedRoutes = const <VRouteElement>[],
  });
}

class TabbedNester extends VRouteElementBuilder {
  final String? path;
  final Widget Function(Widget child, int currentTabIndex) widgetBuilder;

  /// The route(s) that should be associated with each tab entry.
  /// Each tab has one entry in this list.
  /// Each entry in this list is either a single VRouteElement,
  /// a list of VRouteElements (becomes nestedRoutes in the VNester
  /// specifically for this tab), or a TabbedNesterEntry (allowing full
  /// specification of both the nestedRoutes and stackedRoutes).
  final List<dynamic> entries;

  /// Set the alias to be the same as the path if you want to avoid
  /// animating between tabs within this route.
  final List<String> aliases;

  TabbedNester({
    required this.path,
    required this.widgetBuilder,
    required this.entries,
    this.aliases = const [],
  });

  @override
  List<VRouteElement> buildRoutes() {
    var routes = <VRouteElement>[];
    for (int i = 0; i < entries.length; i++) {
      var nestedRoutes = const <VRouteElement>[];
      var stackedRoutes = const <VRouteElement>[];
      if (entries[i] is TabbedNesterEntry) {
        var e = entries[i] as TabbedNesterEntry;
        nestedRoutes = e.nestedRoutes;
        stackedRoutes = e.stackedRoutes;
      } else if (entries[i] is List<VRouteElement>) {
        nestedRoutes = entries[i] as List<VRouteElement>;
      } else if (entries[i] is VRouteElement) {
        nestedRoutes = <VRouteElement>[entries[i] as VRouteElement];
      } else {
        throw UnsupportedError("Unknown type of TabbedNester entry #$i");
      }
      routes.add(VNester(
        path: path,
        widgetBuilder: (child) => widgetBuilder(child, i),
        nestedRoutes: nestedRoutes,
        stackedRoutes: stackedRoutes,
      ));
    }
    return routes;
  }
}
```
</details>